### PR TITLE
Replace "Live" with "View" in project links

### DIFF
--- a/projects.html
+++ b/projects.html
@@ -38,7 +38,7 @@
                     <li class="post-item">
                         <a href="/embedding-explorer/">
                             <span class="post-title">Embedding Space Explorer</span>
-                            <span class="post-meta">Live →</span>
+                            <span class="post-meta">View →</span>
                         </a>
                         <p class="post-summary">Interactive 3D visualization of document embeddings using the Enron email corpus. Explore how neural networks understand document similarity, compare generic vs. fine-tuned models, and see nearest neighbors in embedding space.</p>
                     </li>
@@ -51,7 +51,7 @@
                     <li class="post-item">
                         <a href="https://lift.karanpraharaj.com" target="_blank" rel="noopener">
                             <span class="post-title">Omni Lift Tracker</span>
-                            <span class="post-meta">Live →</span>
+                            <span class="post-meta">View →</span>
                         </a>
                         <p class="post-summary">Strength training workout tracker with Wendler 5-3-1 programming
                             support. Auto-calculated sets, 4-week cycle tracking, 1RM estimation, joker sets, and


### PR DESCRIPTION
Cleaner, more direct call-to-action text for project links